### PR TITLE
ARM: dts: msm: i2c: change clock rate to 19.2 MHz

### DIFF
--- a/arch/arm/boot/dts/lge/msm8974-g2/msm8974-lge-common/msm8974-lge-common.dtsi
+++ b/arch/arm/boot/dts/lge/msm8974-g2/msm8974-lge-common/msm8974-lge-common.dtsi
@@ -86,7 +86,7 @@
 		interrupts = <0 105 0>;
 		interrupt-names = "qup_err_intr";
 		qcom,i2c-bus-freq = <400000>;
-		qcom,i2c-src-freq = <50000000>;
+		qcom,i2c-src-freq = <19200000>;
 		qcom,scl-gpio = <&msmgpio 84 0>;
 		qcom,sda-gpio = <&msmgpio 83 0>;
 		qcom,active-only;


### PR DESCRIPTION
For standard requirement, I2C source
speed of 50MHz causes high power usage, hence
this patch change the clock rate to 19.2 MHz
to save power.

CRs-Fixed: 552956 Change-Id: Ifb17fb79062a390a19881d247a2ac0ca5cc55d80
Signed-off-by: Sana Venkat Raju c_vsana@codeaurora.org

https://www.codeaurora.org/cgit/quic/la/kernel/msm/commit/arch/arm/boot/dts/msm8974.dtsi?h=kk_3.5&id=2762366bdeb1d2d3bb43ffb21ad3a0908d51551e
